### PR TITLE
Support Pagination and Column Blacklist

### DIFF
--- a/examples/async.py
+++ b/examples/async.py
@@ -21,18 +21,19 @@ class Posts(tornado_jsonapi.resource.Resource):
             hsh = hashlib.sha1()
             values = [self.data[attr] for attr in sorted(self.data)]
             for v in values:
-                hsh.update(bytes(str(v), 'utf-8'))
+                hsh.update(bytes(str(v), "utf-8"))
             return hsh.hexdigest()
 
         def type_(self):
-            return 'post'
+            return "post"
 
         def attributes(self):
             return self.data
 
     def __init__(self, data):
         self.data = data
-        schema = json.loads("""
+        schema = json.loads(
+            """
             {
                 "$schema": "http://json-schema.org/draft-04/schema#",
                 "title": "post",
@@ -53,11 +54,12 @@ class Posts(tornado_jsonapi.resource.Resource):
                 "required": [ "text", "author" ],
                 "additionalProperties": false
             }
-            """)
+            """
+        )
         super().__init__(schema)
 
     def name(self):
-        return 'post'
+        return "post"
 
     @gen.coroutine
     def create(self, attributes):
@@ -106,13 +108,16 @@ def main():
     settings = {}
     settings.update(options.group_dict(None))
     settings.update(tornado_jsonapi.handlers.not_found_handling_settings())
-    application = tornado.web.Application([
-        (
-            r"/api/posts/([^/]*)",
-            tornado_jsonapi.handlers.APIHandler,
-            dict(resource=Posts(json.loads(open('data.json').read())))
-        ),
-    ], **settings)
+    application = tornado.web.Application(
+        [
+            (
+                r"/api/posts/([^/]*)",
+                tornado_jsonapi.handlers.APIHandler,
+                dict(resource=Posts(json.loads(open("data.json").read()))),
+            ),
+        ],
+        **settings
+    )
     application.listen(8888)
     tornado.ioloop.IOLoop.current().start()
 

--- a/examples/async.py
+++ b/examples/async.py
@@ -93,7 +93,7 @@ class Posts(tornado_jsonapi.resource.Resource):
         return [Posts.ResourceObject(self, p) for p in self.data]
 
     @gen.coroutine
-    def list_count_(self):
+    def list_count(self):
         return len(self.data)
 
 

--- a/examples/async.py
+++ b/examples/async.py
@@ -89,8 +89,12 @@ class Posts(tornado_jsonapi.resource.Resource):
         return False
 
     @gen.coroutine
-    def list_(self):
+    def list_(self, limit=0, page=0):
         return [Posts.ResourceObject(self, p) for p in self.data]
+
+    @gen.coroutine
+    def list_count_(self):
+        return len(self.data)
 
 
 def main():

--- a/examples/async.py
+++ b/examples/async.py
@@ -90,6 +90,9 @@ class Posts(tornado_jsonapi.resource.Resource):
 
     @gen.coroutine
     def list_(self, limit=0, page=0):
+        """
+        Note that limit and page are not implemented in this example
+        """
         return [Posts.ResourceObject(self, p) for p in self.data]
 
     @gen.coroutine

--- a/examples/dbapi.py
+++ b/examples/dbapi.py
@@ -10,7 +10,8 @@ import tornado_jsonapi.handlers
 import tornado_jsonapi.resource
 
 
-schema = json.loads("""
+schema = json.loads(
+    """
     {
         "$schema": "http://json-schema.org/draft-04/schema#",
         "title": "post",
@@ -31,7 +32,8 @@ schema = json.loads("""
         "required": [ "text", "author" ],
         "additionalProperties": false
     }
-""")
+"""
+)
 
 
 def main():
@@ -41,24 +43,31 @@ def main():
     settings.update(options.group_dict(None))
     settings.update(tornado_jsonapi.handlers.not_found_handling_settings())
 
-    conn = sqlite3.connect(':memory:')
-    
+    conn = sqlite3.connect(":memory:")
 
-    r = tornado_jsonapi.resource.DBAPI2Resource(
-        schema, sqlite3, conn)
+    r = tornado_jsonapi.resource.DBAPI2Resource(schema, sqlite3, conn)
     r._create_table()
 
     cur = conn.cursor()
-    for i in range(1,16):
-        cur.execute("INSERT INTO posts(text,author) VALUES(?,?)", ("Text" + str(i), str(i)))
+    for i in range(1, 16):
+        cur.execute(
+            "INSERT INTO posts(text,author) VALUES(?,?)",
+            (
+                "Text" + str(i),
+                str(i)
+            )
+        )
 
-    application = tornado.web.Application([
-        (
-            r"/api/posts/([^/]*)",
-            tornado_jsonapi.handlers.APIHandler,
-            dict(resource=r)
-        ),
-    ], **settings)
+    application = tornado.web.Application(
+        [
+            (
+                r"/api/posts/([^/]*)",
+                tornado_jsonapi.handlers.APIHandler,
+                dict(resource=r),
+            ),
+        ],
+        **settings
+    )
     application.listen(8888)
     tornado.ioloop.IOLoop.current().start()
 

--- a/examples/dbapi.py
+++ b/examples/dbapi.py
@@ -41,9 +41,17 @@ def main():
     settings.update(options.group_dict(None))
     settings.update(tornado_jsonapi.handlers.not_found_handling_settings())
 
+    conn = sqlite3.connect(':memory:')
+    
+
     r = tornado_jsonapi.resource.DBAPI2Resource(
-        schema, sqlite3, sqlite3.connect(':memory:'))
+        schema, sqlite3, conn)
     r._create_table()
+
+    cur = conn.cursor()
+    for i in range(1,16):
+        cur.execute("INSERT INTO posts(text,author) VALUES(?,?)", ("Text" + str(i), str(i)))
+
     application = tornado.web.Application([
         (
             r"/api/posts/([^/]*)",

--- a/examples/postgre.py
+++ b/examples/postgre.py
@@ -12,7 +12,8 @@ import tornado_jsonapi.handlers
 import tornado_jsonapi.resource
 
 
-schema = json.loads("""
+schema = json.loads(
+    """
     {
         "$schema": "http://json-schema.org/draft-04/schema#",
         "title": "post",
@@ -33,7 +34,8 @@ schema = json.loads("""
         "required": [ "text", "author" ],
         "additionalProperties": false
     }
-""")
+"""
+)
 
 
 def main():
@@ -48,11 +50,8 @@ def main():
     # connect to postgre using momoko
     #  see http://momoko.61924.nl/en/latest/tutorial.html#trival-example
     conn = momoko.Pool(
-        'dbname=postgres '
-        'user=postgres '
-        'host=localhost '
-        'port=5432',
-        ioloop=io_loop
+        "dbname=postgres " "user=postgres " "host=localhost " "port=5432",
+        ioloop=io_loop,
     )
     future = conn.connect()
     io_loop.add_future(future, lambda x: io_loop.stop())
@@ -62,13 +61,16 @@ def main():
     r = tornado_jsonapi.resource.DBAPI2Resource(schema, momoko, connection)
     io_loop.add_future(r._create_table(), lambda x: io_loop.stop())
     io_loop.start()
-    application = tornado.web.Application([
-        (
-            r"/api/posts/([^/]*)",
-            tornado_jsonapi.handlers.APIHandler,
-            dict(resource=r)
-        ),
-    ], **settings)
+    application = tornado.web.Application(
+        [
+            (
+                r"/api/posts/([^/]*)",
+                tornado_jsonapi.handlers.APIHandler,
+                dict(resource=r),
+            ),
+        ],
+        **settings
+    )
     application.listen(8888)
     io_loop.start()
 

--- a/examples/sqla.py
+++ b/examples/sqla.py
@@ -33,6 +33,14 @@ def main():
     engine = create_engine('sqlite:///:memory:', echo=settings['debug'])
     Base.metadata.create_all(engine)
     Session = sessionmaker(bind=engine)
+    
+    s = Session()
+    for i in range(0,10):
+        p = Post()
+        p.author = "Author %d" % i
+        p.text = "Text for %d" % i
+        s.add(p)
+    s.commit()
 
     application = tornado.web.Application([
         (

--- a/examples/sqla.py
+++ b/examples/sqla.py
@@ -4,7 +4,7 @@
 import tornado.ioloop
 from tornado.options import options, define
 
-from sqlalchemy import create_engine, Column, Integer, String
+from sqlalchemy import create_engine, Column, Integer, String, DateTime
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
@@ -21,6 +21,7 @@ class Post(Base):
     id = Column(Integer, primary_key=True)
     author = Column(String)
     text = Column(String)
+    hideMe = Column(DateTime)
 
 
 def main():
@@ -42,12 +43,14 @@ def main():
         s.add(p)
     s.commit()
 
+    postResource = tornado_jsonapi.resource.SQLAlchemyResource(Post, Session)
+    postResource.blacklist.append(Post.hideMe)
+
     application = tornado.web.Application([
         (
             r"/api/posts/([^/]*)",
             tornado_jsonapi.handlers.APIHandler,
-            dict(resource=tornado_jsonapi.resource.SQLAlchemyResource(
-                Post, Session))
+            dict(resource=postResource)
         ),
     ], **settings)
     application.listen(8888)

--- a/examples/sqla.py
+++ b/examples/sqla.py
@@ -15,7 +15,7 @@ Base = declarative_base()
 
 
 class Post(Base):
-    __tablename__ = 'posts'
+    __tablename__ = "posts"
 
     id = Column(Integer, primary_key=True)
     author = Column(String)
@@ -30,14 +30,14 @@ def main():
     settings = {}
     settings.update(options.group_dict(None))
     settings.update(tornado_jsonapi.handlers.not_found_handling_settings())
-    settings.update({'jsonapi_limit': 12})
+    settings.update({"jsonapi_limit": 12})
 
-    engine = create_engine('sqlite:///:memory:', echo=settings['debug'])
+    engine = create_engine("sqlite:///:memory:", echo=settings["debug"])
     Base.metadata.create_all(engine)
     Session = sessionmaker(bind=engine)
-    
+
     s = Session()
-    for i in range(1,16):
+    for i in range(1, 16):
         p = Post()
         p.author = "Author %d" % i
         p.text = "Text for %d" % i
@@ -48,13 +48,16 @@ def main():
     postResource.blacklist.append(Post.hideMe)
     postResource.blacklist.append("hideMe2")
 
-    application = tornado.web.Application([
-        (
-            r"/api/posts/([^/]*)",
-            tornado_jsonapi.handlers.APIHandler,
-            dict(resource=postResource)
-        ),
-    ], **settings)
+    application = tornado.web.Application(
+        [
+            (
+                r"/api/posts/([^/]*)",
+                tornado_jsonapi.handlers.APIHandler,
+                dict(resource=postResource),
+            ),
+        ],
+        **settings
+    )
     application.listen(8888)
     tornado.ioloop.IOLoop.current().start()
 

--- a/examples/sqla.py
+++ b/examples/sqla.py
@@ -30,13 +30,14 @@ def main():
     settings = {}
     settings.update(options.group_dict(None))
     settings.update(tornado_jsonapi.handlers.not_found_handling_settings())
+    settings.update({'jsonapi_limit': 12})
 
     engine = create_engine('sqlite:///:memory:', echo=settings['debug'])
     Base.metadata.create_all(engine)
     Session = sessionmaker(bind=engine)
     
     s = Session()
-    for i in range(0,10):
+    for i in range(1,16):
         p = Post()
         p.author = "Author %d" % i
         p.text = "Text for %d" % i

--- a/examples/sqla.py
+++ b/examples/sqla.py
@@ -11,7 +11,6 @@ from sqlalchemy.orm import sessionmaker
 import tornado_jsonapi.handlers
 import tornado_jsonapi.resource
 
-
 Base = declarative_base()
 
 
@@ -22,6 +21,7 @@ class Post(Base):
     author = Column(String)
     text = Column(String)
     hideMe = Column(DateTime)
+    hideMe2 = Column(String, default="secret")
 
 
 def main():
@@ -46,6 +46,7 @@ def main():
 
     postResource = tornado_jsonapi.resource.SQLAlchemyResource(Post, Session)
     postResource.blacklist.append(Post.hideMe)
+    postResource.blacklist.append("hideMe2")
 
     application = tornado.web.Application([
         (

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'tornado>=4.2',
     ],
     extras_require={
-        'sqlalchemy': ['SQLAlchemy==1.0.12', 'alchemyjsonschema==0.3.3'],
+        'sqlalchemy': ['SQLAlchemy==1.0.12', 'alchemyjsonschema>=0.6.1'],
         'dbapi2': ['antiorm==1.2.0']
     },
     tests_require=['pytest==2.9.1', 'pytest-pep8==1.0.6',

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -15,7 +15,7 @@ from tornado import gen
 import tornado.testing
 from tornado import netutil
 from tornado.testing import AsyncHTTPTestCase
-from tornado.wsgi import WSGIAdapter
+from tornado.wsgi import WSGIContainer
 from http.cookiejar import CookieJar
 
 import tornado_jsonapi.handlers
@@ -94,7 +94,7 @@ class BaseTestCase(AsyncHTTPTestCase):
     def setUp(self):
         AsyncHTTPTestCase.setUp(self)
         self.app = webtest.TestApp(
-            WSGIAdapter(self.get_app()),
+            WSGIContainer(self.get_app()),
             cookiejar=CookieJar())
 
 

--- a/tornado_jsonapi/__init__.py
+++ b/tornado_jsonapi/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # vim: set fileencoding=utf8 :
 
-'''
+"""
 
 Handlers
 --------
@@ -20,8 +20,8 @@ Exceptions
 
 .. automodule:: tornado_jsonapi.exceptions
    :members:
-'''
+"""
 
-__author__ = 'Andrew Kravchuk'
-__email__ = 'awkravchuk@gmail.com'
-__version__ = '0.1.3'
+__author__ = "Andrew Kravchuk"
+__email__ = "awkravchuk@gmail.com"
+__version__ = "0.1.3"

--- a/tornado_jsonapi/_schemas.py
+++ b/tornado_jsonapi/_schemas.py
@@ -8,7 +8,7 @@ import inflection
 
 class Meta(jsl.Document):
     class Options(object):
-        definition_id = 'meta'
+        definition_id = "meta"
         additional_properties = True
 
 
@@ -17,7 +17,7 @@ class Link(jsl.Document):
     meta = jsl.DocumentField(Meta, as_ref=True)
 
     class Options(object):
-        definition_id = 'link'
+        definition_id = "link"
 
 
 class Links(jsl.Document):
@@ -25,7 +25,7 @@ class Links(jsl.Document):
     related = jsl.DocumentField(Link, as_ref=True)
 
     class Options(object):
-        definition_id = 'links'
+        definition_id = "links"
         additional_properties = True
 
 
@@ -37,15 +37,15 @@ class PostResource(jsl.Document):
     meta = jsl.DocumentField(Meta, as_ref=True)
 
     class Options(object):
-        definition_id = 'resource'
+        definition_id = "resource"
 
 
 class PostData(jsl.Document):
     data = jsl.DocumentField(PostResource, as_ref=True)
 
     class Options(object):
-        title = 'Data'
-        definition_id = 'data'
+        title = "Data"
+        definition_id = "data"
 
 
 class PatchResource(jsl.Document):
@@ -56,15 +56,15 @@ class PatchResource(jsl.Document):
     meta = jsl.DocumentField(Meta, as_ref=True)
 
     class Options(object):
-        definition_id = 'resource'
+        definition_id = "resource"
 
 
 class PatchData(jsl.Document):
     data = jsl.DocumentField(PatchResource, as_ref=True)
 
     class Options(object):
-        title = 'Data'
-        definition_id = 'data'
+        title = "Data"
+        definition_id = "data"
 
 
 def _build_schema(cls):

--- a/tornado_jsonapi/exceptions.py
+++ b/tornado_jsonapi/exceptions.py
@@ -8,7 +8,7 @@ import tornado.web
 
 
 class APIError(tornado.web.HTTPError):
-    '''
+    """
     Basic API error for using in client code.
     Each :py:class:`APIError` is assigned an unique error ID, which is both
     written to log and returned to API client (as ``id`` field of ``error``
@@ -28,21 +28,24 @@ class APIError(tornado.web.HTTPError):
     :param str details: Details of the error to be shown to API client and
         written to log. May contain ``%s``-style placeholders, which will be
         filled in with remaining positional parameters.
-    '''
+    """
+
     def __init__(
-            self,
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            details='Unspecified API error',
-            *args, **kwargs):
+        self,
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        details="Unspecified API error",
+        *args,
+        **kwargs
+    ):
         super().__init__(status_code, details, *args, **kwargs)
         self.error_id = APIError._generate_id()
 
     @staticmethod
     def _generate_id():
         now = str(datetime.datetime.utcnow())
-        return hashlib.sha1(bytes(now, 'utf-8')).hexdigest()
+        return hashlib.sha1(bytes(now, "utf-8")).hexdigest()
 
 
 class MissingResourceSchemaError(Exception):
     def __init__(self, resource):
-        self.message = 'Missing schema for resource {}'.format(resource)
+        self.message = "Missing schema for resource {}".format(resource)

--- a/tornado_jsonapi/handlers.py
+++ b/tornado_jsonapi/handlers.py
@@ -235,7 +235,6 @@ class APIHandler(tornado.web.RequestHandler):
         server_limit = (
             self.settings["jsonapi_limit"] if "jsonapi_limit" in self.settings else 0
         )
-        print("server limit", server_limit)
         if server_limit > 0 and (limit > server_limit or limit == 0):
             limit = server_limit
 
@@ -256,7 +255,7 @@ class APIHandler(tornado.web.RequestHandler):
             self.render(
                 res,
                 additional={
-                    "list_limits": {"total": count, "limit": limit, "page": page,}
+                    "limits": {"total": count, "limit": limit, "page": page,}
                 },
             )
         else:

--- a/tornado_jsonapi/handlers.py
+++ b/tornado_jsonapi/handlers.py
@@ -235,7 +235,8 @@ class APIHandler(tornado.web.RequestHandler):
         server_limit = (
             self.settings["jsonapi_limit"] if "jsonapi_limit" in self.settings else 0
         )
-        if server_limit > 0 and limit > server_limit:
+        print("server limit", server_limit)
+        if server_limit > 0 and (limit > server_limit or limit == 0):
             limit = server_limit
 
         page = (

--- a/tornado_jsonapi/handlers.py
+++ b/tornado_jsonapi/handlers.py
@@ -153,10 +153,17 @@ class APIHandler(tornado.web.RequestHandler):
                 raise APIError(status.HTTP_404_NOT_FOUND, "")
         resource_attributes = resource.attributes()
         attributes = self._resource._schema()
+        blacklist_attr = []
         for attr_name in attributes.keys():
             if attr_name in resource_attributes:
                 attributes[attr_name] = resource_attributes[attr_name]
+            else:
+                blacklist_attr.append(attr_name)
+
+        for attr in blacklist_attr:
+            attributes.pop(attr, None)
         attributes.validate()
+
         return {
             "id": resource.id_(),
             "type": resource.type_(),

--- a/tornado_jsonapi/handlers.py
+++ b/tornado_jsonapi/handlers.py
@@ -17,120 +17,140 @@ from .exceptions import APIError
 
 
 class APIHandler(tornado.web.RequestHandler):
-    '''
+    """
     Basic :py:class:`tornado.web.RequestHandler` for JSON API.
     It handles validating both input and output documents, rendering resources
     to JSON, error processing and other aspects of JSON API.
     Subclass it to add extra functionality, e.g. authorization or `JSON API
     extension support <http://jsonapi.org/extensions/>`_.
-    '''
+    """
+
     def initialize(self, resource):
         self._resource = resource
 
     def _get_meta(self):
         return {
-            'meta': {'tornado_jsonapi_version': __version__},
-            'jsonapi': {'version': '1.0'}}
+            "meta": {"tornado_jsonapi_version": __version__},
+            "jsonapi": {"version": "1.0"},
+        }
 
     def _get_content_type(self):
-        return 'application/vnd.api+json'
+        return "application/vnd.api+json"
 
     def set_default_headers(self):
-        self.set_header('Content-Type', self._get_content_type())
+        self.set_header("Content-Type", self._get_content_type())
         self.set_header(
-            'Server',
-            'TornadoServer/{} tornado_jsonapi/{}'.
-            format(tornado.version, __version__))
+            "Server",
+            "TornadoServer/{} tornado_jsonapi/{}".format(tornado.version, __version__),
+        )
 
     def write_error(self, status_code, **kwargs):
-        exc_info = kwargs['exc_info'] if 'exc_info' in kwargs else None
+        exc_info = kwargs["exc_info"] if "exc_info" in kwargs else None
         exception = exc_info[1] if exc_info else None
-        reason = ''
+        reason = ""
         if isinstance(exception, tornado.web.HTTPError):
             reason = exception.reason
         if not reason:
-            reason = tornado.httputil.responses.get(
-                status_code,
-                'Unknown error')
-        detail = ''
+            reason = tornado.httputil.responses.get(status_code, "Unknown error")
+        detail = ""
         if isinstance(exception, tornado.web.HTTPError):
-            detail = exception.log_message % exception.args \
-                if exception.log_message else reason
-        if self.settings.get('serve_traceback') and exc_info:
+            detail = (
+                exception.log_message % exception.args
+                if exception.log_message
+                else reason
+            )
+        if self.settings.get("serve_traceback") and exc_info:
             # in debug mode, try to send a traceback
             for line in traceback.format_exception(*exc_info):
-                detail += '\r\n' + line
-        error_id = exception.error_id if hasattr(exception, 'error_id') \
+                detail += "\r\n" + line
+        error_id = (
+            exception.error_id
+            if hasattr(exception, "error_id")
             else APIError._generate_id()
-        self.finish(json.dumps(
-            dict(
-                errors=[{
-                    'id': error_id,
-                    'status': str(status_code),
-                    'title': reason,
-                    'detail': detail
-                }],
-                **self._get_meta()),
-            ensure_ascii=False, indent=4))
+        )
+        self.finish(
+            json.dumps(
+                dict(
+                    errors=[
+                        {
+                            "id": error_id,
+                            "status": str(status_code),
+                            "title": reason,
+                            "detail": detail,
+                        }
+                    ],
+                    **self._get_meta()
+                ),
+                ensure_ascii=False,
+                indent=4,
+            )
+        )
 
     def log_exception(self, typ, value, tb):
         if isinstance(value, APIError):
             app_log.error(
-                'API error %s: %s\n%r',
+                "API error %s: %s\n%r",
                 value.error_id,
-                value.log_message % value.args if value.log_message else '',
+                value.log_message % value.args if value.log_message else "",
                 self.request,
-                exc_info=(typ, value, tb))
+                exc_info=(typ, value, tb),
+            )
         elif isinstance(value, tornado.web.HTTPError):
             if value.log_message:
                 format = "%d %s: " + value.log_message
-                args = ([value.status_code, self._request_summary()] +
-                        list(value.args))
+                args = [value.status_code, self._request_summary()] + list(value.args)
                 gen_log.warning(format, *args)
         else:
             value.error_id = APIError._generate_id()
-            app_log.error("Uncaught exception %s %s\n%r",
-                          self._request_summary(), value.error_id,
-                          self.request, exc_info=(typ, value, tb))
+            app_log.error(
+                "Uncaught exception %s %s\n%r",
+                self._request_summary(),
+                value.error_id,
+                self.request,
+                exc_info=(typ, value, tb),
+            )
 
     def acceptable(self, extensions):
-        '''
+        """
         Return whether server supports given extensions. By default do not
         support any extensions.
 
         :param dict sender: dictionary of Accept header parameters, e.g.
             :code:`{'supported-ext': 'bulk,jsonpatch'}`
-        '''
+        """
         return not extensions
 
     def prepare(self):
         if len(self.request.body) != 0:
-            mt = accept.parse(self.request.headers.get('Content-Type'))[0]
-            if mt.media_type != self._get_content_type() or \
-                    not self.acceptable(mt.params):
-                raise APIError(status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, '')
-        accept_header = self.request.headers.get('Accept')
+            mt = accept.parse(self.request.headers.get("Content-Type"))[0]
+            if mt.media_type != self._get_content_type() or not self.acceptable(
+                mt.params
+            ):
+                raise APIError(status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, "")
+        accept_header = self.request.headers.get("Accept")
         if not accept_header:
             return  # allow missing Accept header
         for a in accept.parse(accept_header):
-            if a.all_types or \
-                    a.media_type.split('/')[0] == 'application' and \
-                    a.all_subtypes:
+            if (
+                a.all_types
+                or a.media_type.split("/")[0] == "application"
+                and a.all_subtypes
+            ):
                 return
             if a.media_type == self._get_content_type():
                 if self.acceptable(a.params):
                     return
-        raise APIError(status.HTTP_406_NOT_ACCEPTABLE, '')
+        raise APIError(status.HTTP_406_NOT_ACCEPTABLE, "")
 
     def render_resource(self, resource, nullable=True):
-        '''
+        """
         Utility function
-        '''
+        """
         if resource is None:
             if nullable:
                 return None
             else:
-                raise APIError(status.HTTP_404_NOT_FOUND, '')
+                raise APIError(status.HTTP_404_NOT_FOUND, "")
         resource_attributes = resource.attributes()
         attributes = self._resource._schema()
         for attr_name in attributes.keys():
@@ -138,73 +158,95 @@ class APIHandler(tornado.web.RequestHandler):
                 attributes[attr_name] = resource_attributes[attr_name]
         attributes.validate()
         return {
-            'id': resource.id_(),
-            'type': resource.type_(),
-            'attributes': attributes._properties}
+            "id": resource.id_(),
+            "type": resource.type_(),
+            "attributes": attributes._properties,
+        }
 
-    def render(self, resources, nullable=True):
+    def render(self, resources, nullable=True, additional=None):
+        data = {}
         json_resources = []
         if isinstance(resources, collections.Sequence):
             for resource in resources:
                 json_resources.append(self.render_resource(resource))
+            data.update({"data_len": len(resources)})
         else:
             json_resources = self.render_resource(resources, nullable)
-        self.finish(json.dumps(dict(
-            data=json_resources,
-            **self._get_meta()),
-            ensure_ascii=False, indent=4))
+
+        if additional:
+            data.update(additional)
+        data.update(dict(data=json_resources, **self._get_meta()))
+
+        self.finish(json.dumps(data, ensure_ascii=False, indent=4))
 
     def _get_request_data(self, schema):
-        '''
+        """
         Get and validate request JSON data according to given schema
-        '''
+        """
         try:
-            d = json.loads(self.request.body.decode(encoding='UTF-8'))
+            d = json.loads(self.request.body.decode(encoding="UTF-8"))
         except ValueError as err:
-            raise APIError(
-                status.HTTP_400_BAD_REQUEST,
-                str(err)) from err
+            raise APIError(status.HTTP_400_BAD_REQUEST, str(err)) from err
         try:
             data = schema(**d)
             data.validate()
         except pjs.validators.ValidationError as err:
-            raise APIError(
-                status.HTTP_400_BAD_REQUEST,
-                str(err)) from err
-        return data['data']
+            raise APIError(status.HTTP_400_BAD_REQUEST, str(err)) from err
+        return data["data"]
 
     def _get_resource(self, data, validate=True):
-        if data.get('type') != self._resource.name():
+        if data.get("type") != self._resource.name():
             raise APIError(
                 status.HTTP_409_CONFLICT,
-                'Expecting object of type "%s"', self._resource.name())
-        if data['attributes'] is None:
-            raise APIError(
-                status.HTTP_400_BAD_REQUEST,
-                'Missing object attributes')
-        attributes = data['attributes'].as_dict()
+                'Expecting object of type "%s"',
+                self._resource.name(),
+            )
+        if data["attributes"] is None:
+            raise APIError(status.HTTP_400_BAD_REQUEST, "Missing object attributes")
+        attributes = data["attributes"].as_dict()
         if validate:
             try:
                 attrs = self._resource._schema(**attributes)
                 attrs.validate()
             except pjs.validators.ValidationError as err:
-                raise APIError(
-                    status.HTTP_400_BAD_REQUEST,
-                    str(err)) from err
+                raise APIError(status.HTTP_400_BAD_REQUEST, str(err)) from err
         return attributes
 
     @tornado.gen.coroutine
     def get(self, id_=None):
-        '''
+        """
         GET method, see
         `spec <http://jsonapi.org/format/1.0/#fetching-resources>`__.
         Decorate with :py:func:`tornado.gen.coroutine` when subclassing.
-        '''
+        """
+
+        limit = (
+            int(self.request.arguments["limit"][0])
+            if "limit" in self.request.arguments
+            else 0
+        )
+        server_limit = (
+            self.settings["jsonapi_limit"] if "jsonapi_limit" in self.settings else 0
+        )
+        if server_limit > 0 and limit > server_limit:
+            limit = server_limit
+
+        page = (
+            int(self.request.arguments["page"][0])
+            if "page" in self.request.arguments
+            else 0
+        )
+
         if not id_:
-            res = self._resource.list_()
+            (res, total) = self._resource.list_(limit=limit, page=page)
             while is_future(res):
                 res = yield res
-            self.render(res)
+            self.render(
+                res,
+                additional={
+                    "list_limits": {"total": total, "limit": limit, "page": page,}
+                },
+            )
         else:
             res = self._resource.read(id_)
             while is_future(res):
@@ -213,46 +255,45 @@ class APIHandler(tornado.web.RequestHandler):
 
     @tornado.gen.coroutine
     def post(self, id_=None):
-        '''
+        """
         POST method, see
         `spec <http://jsonapi.org/format/1.0/#crud-creating>`__.
         Decorate with :py:func:`tornado.gen.coroutine` when subclassing.
-        '''
+        """
         if id_:
-            raise APIError(status.HTTP_400_BAD_REQUEST, 'Extra id in request')
+            raise APIError(status.HTTP_400_BAD_REQUEST, "Extra id in request")
         data = self._get_request_data(_schemas.postDataSchema())
-        if data['id'] is not None:
+        if data["id"] is not None:
             raise APIError(
                 status.HTTP_403_FORBIDDEN,
-                'Client-generated resource ID is not supported')
+                "Client-generated resource ID is not supported",
+            )
         resource = self._resource.create(self._get_resource(data))
         while is_future(resource):
             resource = yield resource
         if not resource:
             raise APIError()
         self.set_status(status.HTTP_201_CREATED)
-        self.set_header(
-            'Location',
-            self.request.uri + resource.id_())
+        self.set_header("Location", self.request.uri + resource.id_())
         self.render(resource)
 
     @tornado.gen.coroutine
     def patch(self, id_):
-        '''
+        """
         PATCH method, see
         `spec <http://jsonapi.org/format/1.0/#crud-updating>`__.
         Decorate with :py:func:`tornado.gen.coroutine` when subclassing.
-        '''
+        """
         if not id_:
-            raise APIError(status.HTTP_400_BAD_REQUEST, 'Missing ID')
+            raise APIError(status.HTTP_400_BAD_REQUEST, "Missing ID")
         data = self._get_request_data(_schemas.patchDataSchema())
-        if data['id'] != id_:
-            raise APIError(status.HTTP_400_BAD_REQUEST, 'ID mismatch')
+        if data["id"] != id_:
+            raise APIError(status.HTTP_400_BAD_REQUEST, "ID mismatch")
         exists = self._resource.exists(id_)
         while is_future(exists):
             exists = yield exists
         if not exists:
-            raise APIError(status.HTTP_404_NOT_FOUND, 'No such resource')
+            raise APIError(status.HTTP_404_NOT_FOUND, "No such resource")
         res = self._get_resource(data, validate=False)
         resource = self._resource.update(id_, res)
         while is_future(resource):
@@ -263,44 +304,45 @@ class APIHandler(tornado.web.RequestHandler):
 
     @tornado.gen.coroutine
     def delete(self, id_):
-        '''
+        """
         DELETE method, see
         `spec <http://jsonapi.org/format/1.0/#crud-deleting>`__.
         Decorate with :py:func:`tornado.gen.coroutine` when subclassing.
-        '''
+        """
         if not id_:
-            raise APIError(status.HTTP_400_BAD_REQUEST, 'Missing ID')
+            raise APIError(status.HTTP_400_BAD_REQUEST, "Missing ID")
         exists = self._resource.exists(id_)
         while is_future(exists):
             exists = yield exists
         if not exists:
-            raise APIError(status.HTTP_404_NOT_FOUND, 'No such resource')
+            raise APIError(status.HTTP_404_NOT_FOUND, "No such resource")
         res = self._resource.delete(id_)
         while is_future(res):
             res = yield res
         if not res:
             raise APIError()
         self.set_status(status.HTTP_204_NO_CONTENT)
-        self.clear_header('Content-Type')
+        self.clear_header("Content-Type")
 
     def on_finish(self):
-        if hasattr(self._resource, '_on_request_end'):
+        if hasattr(self._resource, "_on_request_end"):
             self._resource._on_request_end()
 
 
 class NotFoundErrorAPIHandler(APIHandler):
-    '''
+    """
     Handler for 404 error providing correct API
     `response <http://jsonapi.org/format/1.0/#error-objects>`_. Do not use it
     directly, use :py:func:`not_found_handling_settings` instead.
-    '''
+    """
+
     def prepare(self):
         super().prepare()
-        raise APIError(status.HTTP_404_NOT_FOUND, 'Resource not found')
+        raise APIError(status.HTTP_404_NOT_FOUND, "Resource not found")
 
 
 def not_found_handling_settings():
-    '''
+    """
     Settings dict for :py:class:`tornado.web.Application` to use
     :py:class:`NotFoundErrorAPIHandler` as default 404 error handler. Use this
     as follows:
@@ -314,7 +356,8 @@ def not_found_handling_settings():
             ),
         ], **tornado_jsonapi.handlers.not_found_handling_settings())
         application.listen()
-    '''
+    """
     return {
-        'default_handler_class': NotFoundErrorAPIHandler,
-        'default_handler_args': dict(resource={})}
+        "default_handler_class": NotFoundErrorAPIHandler,
+        "default_handler_args": dict(resource={}),
+    }

--- a/tornado_jsonapi/handlers.py
+++ b/tornado_jsonapi/handlers.py
@@ -41,7 +41,9 @@ class APIHandler(tornado.web.RequestHandler):
         self.set_header("Content-Type", self._get_content_type())
         self.set_header(
             "Server",
-            "TornadoServer/{} tornado_jsonapi/{}".format(tornado.version, __version__),
+            "TornadoServer/{} tornado_jsonapi/{}".format(
+                tornado.version, __version__
+            ),
         )
 
     def write_error(self, status_code, **kwargs):
@@ -51,7 +53,9 @@ class APIHandler(tornado.web.RequestHandler):
         if isinstance(exception, tornado.web.HTTPError):
             reason = exception.reason
         if not reason:
-            reason = tornado.httputil.responses.get(status_code, "Unknown error")
+            reason = tornado.httputil.responses.get(
+                status_code, "Unknown error"
+            )
         detail = ""
         if isinstance(exception, tornado.web.HTTPError):
             detail = (
@@ -98,7 +102,9 @@ class APIHandler(tornado.web.RequestHandler):
         elif isinstance(value, tornado.web.HTTPError):
             if value.log_message:
                 format = "%d %s: " + value.log_message
-                args = [value.status_code, self._request_summary()] + list(value.args)
+                args = [value.status_code, self._request_summary()] + list(
+                    value.args
+                )
                 gen_log.warning(format, *args)
         else:
             value.error_id = APIError._generate_id()
@@ -209,7 +215,9 @@ class APIHandler(tornado.web.RequestHandler):
                 self._resource.name(),
             )
         if data["attributes"] is None:
-            raise APIError(status.HTTP_400_BAD_REQUEST, "Missing object attributes")
+            raise APIError(
+                status.HTTP_400_BAD_REQUEST, "Missing object attributes"
+            )
         attributes = data["attributes"].as_dict()
         if validate:
             try:
@@ -233,7 +241,9 @@ class APIHandler(tornado.web.RequestHandler):
             else 0
         )
         server_limit = (
-            self.settings["jsonapi_limit"] if "jsonapi_limit" in self.settings else 0
+            self.settings["jsonapi_limit"]
+            if "jsonapi_limit" in self.settings
+            else 0
         )
         if server_limit > 0 and (limit > server_limit or limit == 0):
             limit = server_limit
@@ -255,7 +265,7 @@ class APIHandler(tornado.web.RequestHandler):
             self.render(
                 res,
                 additional={
-                    "limits": {"total": count, "limit": limit, "page": page,}
+                    "limits": {"total": count, "limit": limit, "page": page}
                 },
             )
         else:

--- a/tornado_jsonapi/handlers.py
+++ b/tornado_jsonapi/handlers.py
@@ -246,13 +246,17 @@ class APIHandler(tornado.web.RequestHandler):
         )
 
         if not id_:
-            (res, total) = self._resource.list_(limit=limit, page=page)
+            res = self._resource.list_(limit=limit, page=page)
             while is_future(res):
                 res = yield res
+            count = self._resource.list_count_()
+            while is_future(count):
+                count = yield count
+
             self.render(
                 res,
                 additional={
-                    "list_limits": {"total": total, "limit": limit, "page": page,}
+                    "list_limits": {"total": count, "limit": limit, "page": page,}
                 },
             )
         else:

--- a/tornado_jsonapi/handlers.py
+++ b/tornado_jsonapi/handlers.py
@@ -249,7 +249,7 @@ class APIHandler(tornado.web.RequestHandler):
             res = self._resource.list_(limit=limit, page=page)
             while is_future(res):
                 res = yield res
-            count = self._resource.list_count_()
+            count = self._resource.list_count()
             while is_future(count):
                 count = yield count
 

--- a/tornado_jsonapi/resource.py
+++ b/tornado_jsonapi/resource.py
@@ -54,8 +54,9 @@ class Resource:
     def delete(self, id_):
         raise NotImplementedError
 
-    def list_(self):
+    def list_(self, limit=0, page=0):
         raise NotImplementedError
+
 
 try:
     import sqlalchemy
@@ -72,28 +73,24 @@ class SQLAlchemyResource(Resource):
             self.model = model
 
         def id_(self):
-            return str(self.model.__getattribute__(
-                self.resource._primary_columns[0]))
+            return str(self.model.__getattribute__(self.resource._primary_columns[0]))
 
         def type_(self):
             return self.resource.name()
 
         def attributes(self):
-            return alchemyjsonschema.dictify.jsonify(self.model,
-                                                     self.resource.schema)
+            return alchemyjsonschema.dictify.jsonify(self.model, self.resource.schema)
 
     def __init__(self, model_cls, sessionmaker):
         self._primary_columns = model_cls.__table__.primary_key.columns.keys()
         if len(self._primary_columns) > 1:
-            raise NotImplementedError('Compound primary keys not supported')
+            raise NotImplementedError("Compound primary keys not supported")
         self.model_cls = model_cls
+        self.model_primary_key = getattr(self.model_cls, self._primary_columns[0])
         self.sessionmaker = sessionmaker
         self.session = sqlalchemy.orm.scoped_session(sessionmaker)
-        factory = alchemyjsonschema.SchemaFactory(
-            alchemyjsonschema.AlsoChildrenWalker)
-        schema = factory(
-            self.model_cls,
-            excludes=self._primary_columns)
+        factory = alchemyjsonschema.SchemaFactory(alchemyjsonschema.StructuralWalker)
+        schema = factory(self.model_cls, excludes=self._primary_columns)
         super().__init__(schema)
 
     def _on_request_end(self):
@@ -103,12 +100,16 @@ class SQLAlchemyResource(Resource):
         return {self._primary_columns[0]: id_}
 
     def name(self):
-        return inflection.camelize(self.model_cls.__name__,
-                                   uppercase_first_letter=False)
+        return inflection.camelize(
+            self.model_cls.__name__, uppercase_first_letter=False
+        )
 
     def exists(self, id_):
-        return self.session.query(self.session.query(self.model_cls).filter_by(
-            **self._id_filter(id_)).exists()).scalar()
+        return self.session.query(
+            self.session.query(self.model_cls)
+            .filter_by(**self._id_filter(id_))
+            .exists()
+        ).scalar()
 
     def create(self, attributes):
         model = self.model_cls(**attributes)
@@ -117,14 +118,17 @@ class SQLAlchemyResource(Resource):
         return SQLAlchemyResource.ResourceObject(self, model)
 
     def read(self, id_):
-        model = self.session.query(self.model_cls).filter_by(
-            **self._id_filter(id_)).one_or_none()
-        return None if model is None else \
-            SQLAlchemyResource.ResourceObject(self, model)
+        model = (
+            self.session.query(self.model_cls)
+            .filter_by(**self._id_filter(id_))
+            .one_or_none()
+        )
+        return None if model is None else SQLAlchemyResource.ResourceObject(self, model)
 
     def update(self, id_, attributes):
-        model = self.session.query(self.model_cls).filter_by(
-            **self._id_filter(id_)).one()
+        model = (
+            self.session.query(self.model_cls).filter_by(**self._id_filter(id_)).one()
+        )
         for k, v in attributes.items():
             setattr(model, k, v)
         self.session.merge(model)
@@ -134,17 +138,27 @@ class SQLAlchemyResource(Resource):
     def delete(self, id_):
         # TODO shouldnt it be
         #  http://docs.sqlalchemy.org/en/latest/core/tutorial.html#deletes
-        r = self.session.query(self.model_cls).filter_by(
-            **self._id_filter(id_)).delete()
+        r = (
+            self.session.query(self.model_cls)
+            .filter_by(**self._id_filter(id_))
+            .delete()
+        )
         self.session.commit()
         return r
 
-    def list_(self):
-        models = self.session.query(self.model_cls)
+    def list_(self, limit=0, page=0):
+        count = self.session.query(sqlalchemy.func.count(self.model_primary_key)).scalar()
+
+        if limit > 0:
+            start = abs(page) * limit
+            stop = start + limit
+            models = self.session.query(self.model_cls).slice(start, stop)
+        else:
+            models = self.session.query(self.model_cls)
         res = []
         for model in models:
             res.append(SQLAlchemyResource.ResourceObject(self, model))
-        return res
+        return (res, count)
 
 
 try:
@@ -174,7 +188,7 @@ def dbapi2Cursor(connection, transaction=False):
 
 @gen.coroutine
 def momokoCursor(pool, transaction=False):
-    class wrapper():
+    class wrapper:
         def __init__(self, pool, connection, transaction):
             self.pool = pool
             self.connection = connection
@@ -187,23 +201,23 @@ def momokoCursor(pool, transaction=False):
         def __exit__(self, type_, value, traceback):
             if self.transaction:
                 if type_ is None:
-                    yield self.connection.execute('COMMIT')
+                    yield self.connection.execute("COMMIT")
                 else:
-                    yield self.connection.execute('ROLLBACK')
+                    yield self.connection.execute("ROLLBACK")
             self.pool.putconn(self.connection)
 
     connection = yield pool.getconn(ping=False)
     if transaction:
-        yield connection.execute('BEGIN')
+        yield connection.execute("BEGIN")
     return wrapper(pool, connection, transaction)
 
 
 class DBAPI2Resource(Resource):
     _types_mapping = {
-        'boolean': 'boolean',
-        'integer': 'integer',
-        'number': 'numeric',
-        'string': 'text'
+        "boolean": "boolean",
+        "integer": "integer",
+        "number": "numeric",
+        "string": "text",
     }
 
     class ResourceObject:
@@ -219,59 +233,64 @@ class DBAPI2Resource(Resource):
             return self._resource.name()
 
         def attributes(self):
-            return {n: v for (n, v) in zip(self._resource.columns,
-                                           self.row[:-1])}
+            return {n: v for (n, v) in zip(self._resource.columns, self.row[:-1])}
 
     def __init__(self, schema, dbapi, connection):
         self.cursor = dbapi2Cursor
         self.connection = connection
         self.dbapi = dbapi
-        if dbapi.__name__ == 'momoko':
+        if dbapi.__name__ == "momoko":
             self.cursor = momokoCursor
             self.dbapi = dbapi.psycopg2
         dbapiext.set_paramstyle(self.dbapi)
-        self._tablename = inflection.pluralize(schema['title'])
+        self._tablename = inflection.pluralize(schema["title"])
         super().__init__(schema)
         self.columns = list(self._schema()._properties.keys())
 
     def _is_sqlite(self):
-        return self.dbapi.__name__ == 'sqlite3'
+        return self.dbapi.__name__ == "sqlite3"
 
     def _is_postgresql(self):
-        return self.dbapi.__name__ == 'psycopg2'
+        return self.dbapi.__name__ == "psycopg2"
 
     def _create_primary_key(self):
-        id_type = 'integer'
+        id_type = "integer"
         if self._is_postgresql():
-            id_type = 'bigserial'
-        key = 'id {} not null primary key'.format(id_type)
+            id_type = "bigserial"
+        key = "id {} not null primary key".format(id_type)
         if self._is_sqlite():
-            key += ' autoincrement'
+            key += " autoincrement"
         return key
 
     @gen.coroutine
     def _create_table(self):
-        types = [self._types_mapping[self._schema.propinfo(c)['type']] +
-                 (' not null' if c in self._schema.__required__ else '')
-                 for c in self.columns]
-        column_defs = [self._create_primary_key()] + \
-            ['{} {}'.format(c, t) for c, t in zip(self.columns, types)]
+        types = [
+            self._types_mapping[self._schema.propinfo(c)["type"]]
+            + (" not null" if c in self._schema.__required__ else "")
+            for c in self.columns
+        ]
+        column_defs = [self._create_primary_key()] + [
+            "{} {}".format(c, t) for c, t in zip(self.columns, types)
+        ]
         with (yield self.cursor(self.connection, transaction=True)) as cursor:
             cur = dbapiext.execute_f(
                 cursor,
-                'create table if not exists %s (%s)',
-                self._tablename, column_defs)
+                "create table if not exists %s (%s)",
+                self._tablename,
+                column_defs,
+            )
             if is_future(cur):
                 yield cur
 
     def name(self):
-        return self.schema['title']
+        return self.schema["title"]
 
     @gen.coroutine
     def exists(self, id_):
         with (yield self.cursor(self.connection)) as cursor:
-            cur = dbapiext.execute_f(cursor, 'select 1 from %s where id = %X',
-                                     self._tablename, id_)
+            cur = dbapiext.execute_f(
+                cursor, "select 1 from %s where id = %X", self._tablename, id_
+            )
             if is_future(cur):
                 cur = yield cur
             return cur.fetchone() is not None
@@ -281,9 +300,10 @@ class DBAPI2Resource(Resource):
         with (yield self.cursor(self.connection, transaction=True)) as cursor:
             cur = dbapiext.execute_f(
                 cursor,
-                'insert into %s (%s) values (%X)',
-                self._tablename, list(attributes.keys()),
-                list(attributes.values())
+                "insert into %s (%s) values (%X)",
+                self._tablename,
+                list(attributes.keys()),
+                list(attributes.values()),
             )
             if is_future(cur):
                 cur = yield cur
@@ -291,8 +311,10 @@ class DBAPI2Resource(Resource):
             # XXX assuming id is monotonically increasing
             cur = dbapiext.execute_f(
                 cursor,
-                'select %s from %s order by id desc limit 1',
-                self.columns + ['id'], self._tablename)
+                "select %s from %s order by id desc limit 1",
+                self.columns + ["id"],
+                self._tablename,
+            )
             if is_future(cur):
                 cur = yield cur
             return DBAPI2Resource.ResourceObject(self, cur.fetchone())
@@ -300,9 +322,13 @@ class DBAPI2Resource(Resource):
     @gen.coroutine
     def read(self, id_):
         with (yield self.cursor(self.connection)) as cursor:
-            cur = dbapiext.execute_f(cursor, 'select %s from %s where id = %X',
-                                     self.columns + ['id'],
-                                     self._tablename, id_)
+            cur = dbapiext.execute_f(
+                cursor,
+                "select %s from %s where id = %X",
+                self.columns + ["id"],
+                self._tablename,
+                id_,
+            )
             if is_future(cur):
                 cur = yield cur
             row = cur.fetchone()
@@ -315,14 +341,21 @@ class DBAPI2Resource(Resource):
         with (yield self.cursor(self.connection, transaction=True)) as cursor:
             cur = dbapiext.execute_f(
                 cursor,
-                'update %s set %X where id = %X',
-                self._tablename, attributes, id_)
+                "update %s set %X where id = %X",
+                self._tablename,
+                attributes,
+                id_,
+            )
             if is_future(cur):
                 cur = yield cur
         with (yield self.cursor(self.connection)) as cursor:
-            cur = dbapiext.execute_f(cursor, 'select %s from %s where id = %X',
-                                     self.columns + ['id'],
-                                     self._tablename, id_)
+            cur = dbapiext.execute_f(
+                cursor,
+                "select %s from %s where id = %X",
+                self.columns + ["id"],
+                self._tablename,
+                id_,
+            )
             if is_future(cur):
                 cur = yield cur
             return DBAPI2Resource.ResourceObject(self, cur.fetchone())
@@ -330,18 +363,23 @@ class DBAPI2Resource(Resource):
     @gen.coroutine
     def delete(self, id_):
         with (yield self.cursor(self.connection, transaction=True)) as cursor:
-            cur = dbapiext.execute_f(cursor, 'delete from %s where id = %X',
-                                     self._tablename, id_)
+            cur = dbapiext.execute_f(
+                cursor, "delete from %s where id = %X", self._tablename, id_
+            )
             if is_future(cur):
                 cur = yield cur
             return cur.rowcount
 
     @gen.coroutine
-    def list_(self):
+    def list_(self, limit=0, page=0):
         with (yield self.cursor(self.connection)) as cursor:
-            cur = dbapiext.execute_f(cursor, 'select %s from %s',
-                                     self.columns + ['id'], self._tablename)
+            cur = dbapiext.execute_f(
+                cursor, "select %s from %s", self.columns + ["id"], self._tablename
+            )
             if is_future(cur):
                 cur = yield cur
             rows = cur.fetchall()
-            return [DBAPI2Resource.ResourceObject(self, row) for row in rows]
+            return (
+                [DBAPI2Resource.ResourceObject(self, row) for row in rows],
+                len(rows),
+            )

--- a/tornado_jsonapi/resource.py
+++ b/tornado_jsonapi/resource.py
@@ -71,7 +71,7 @@ class SQLAlchemyResource(Resource):
         def __init__(self, resource, model, blacklist=None):
             self.resource = resource
             self.model = model
-            self.blacklist=blacklist
+            self.blacklist = blacklist
             if self.blacklist is None:
                 self.blacklist = []
 
@@ -82,7 +82,9 @@ class SQLAlchemyResource(Resource):
             return self.resource.name()
 
         def attributes(self):
-            attributes_ = alchemyjsonschema.dictify.jsonify(self.model, self.resource.schema)
+            attributes_ = alchemyjsonschema.dictify.jsonify(
+                self.model, self.resource.schema
+            )
             for key in self.blacklist:
                 attributes_.pop(key, None)
             return attributes_
@@ -130,7 +132,13 @@ class SQLAlchemyResource(Resource):
             .filter_by(**self._id_filter(id_))
             .one_or_none()
         )
-        return None if model is None else SQLAlchemyResource.ResourceObject(self, model, blacklist=self.blacklist)
+        return (
+            None
+            if model is None
+            else SQLAlchemyResource.ResourceObject(
+                self, model, blacklist=self.blacklist
+            )
+        )
 
     def update(self, id_, attributes):
         model = (
@@ -154,7 +162,9 @@ class SQLAlchemyResource(Resource):
         return r
 
     def list_(self, limit=0, page=0):
-        count = self.session.query(sqlalchemy.func.count(self.model_primary_key)).scalar()
+        count = self.session.query(
+            sqlalchemy.func.count(self.model_primary_key)
+        ).scalar()
 
         if limit > 0:
             start = abs(page) * limit
@@ -164,7 +174,9 @@ class SQLAlchemyResource(Resource):
             models = self.session.query(self.model_cls)
         res = []
         for model in models:
-            res.append(SQLAlchemyResource.ResourceObject(self, model, blacklist=self.blacklist))
+            res.append(
+                SQLAlchemyResource.ResourceObject(self, model, blacklist=self.blacklist)
+            )
         return (res, count)
 
 

--- a/tornado_jsonapi/resource.py
+++ b/tornado_jsonapi/resource.py
@@ -406,7 +406,11 @@ class DBAPI2Resource(Resource):
 
     @gen.coroutine
     def list_count(self):
-        count = self.list_()
-        while is_future(count):
-            count = yield count
-        return len(count)
+        with (yield self.cursor(self.connection)) as cursor:
+            cur = dbapiext.execute_f(
+                cursor, "select count(1) from %s", self._tablename
+            )
+            if is_future(cur):
+                cur = yield cur
+            rows = cur.fetchone()
+            return rows[0]

--- a/tornado_jsonapi/resource.py
+++ b/tornado_jsonapi/resource.py
@@ -57,7 +57,7 @@ class Resource:
     def list_(self, limit=0, page=0):
         raise NotImplementedError
 
-    def list_count_(self):
+    def list_count(self):
         raise NotImplementedError
 
 
@@ -164,7 +164,7 @@ class SQLAlchemyResource(Resource):
         self.session.commit()
         return r
 
-    def list_count_(self):
+    def list_count(self):
         return self.session.query(
             sqlalchemy.func.count(self.model_primary_key)
         ).scalar()
@@ -405,7 +405,7 @@ class DBAPI2Resource(Resource):
             return [DBAPI2Resource.ResourceObject(self, row) for row in rows]
 
     @gen.coroutine
-    def list_count_(self):
+    def list_count(self):
         count = self.list_()
         while is_future(count):
             count = yield count

--- a/tornado_jsonapi/resource.py
+++ b/tornado_jsonapi/resource.py
@@ -396,9 +396,16 @@ class DBAPI2Resource(Resource):
     @gen.coroutine
     def list_(self, limit=0, page=0):
         with (yield self.cursor(self.connection)) as cursor:
-            cur = dbapiext.execute_f(
-                cursor, "select %s from %s", self.columns + ["id"], self._tablename
-            )
+            if limit > 0:
+                start = abs(page)*limit
+                end = limit
+                cur = dbapiext.execute_f(
+                    cursor, "select %s from %s limit %d,%d", self.columns + ["id"], self._tablename, start, end
+                )
+            else:
+                cur = dbapiext.execute_f(
+                    cursor, "select %s from %s", self.columns + ["id"], self._tablename
+                )
             if is_future(cur):
                 cur = yield cur
             rows = cur.fetchall()


### PR DESCRIPTION
Used [black](https://black.readthedocs.io/en/stable/index.html) for code formatting

For the [sqla.py](examples/sqla.py) example you can try the following:

http://localhost:8888/api/posts/?limit=1
http://localhost:8888/api/posts/?limit=2&page=2

You'll see the server has a [hard limit of 12](https://github.com/lockie/tornado_jsonapi/pull/2/files#diff-17ecd233edf87877621cce5904a6f237R33) but you can request a smaller limit if desired.

Blacklisting is as simple as [adding the column](https://github.com/lockie/tornado_jsonapi/pull/2/files#diff-17ecd233edf87877621cce5904a6f237R48) to the resource blacklist
